### PR TITLE
css: highlight table rows on hover

### DIFF
--- a/billtracker/static/css/billtracker.css
+++ b/billtracker/static/css/billtracker.css
@@ -99,6 +99,9 @@ table.definitions th {
 tr.odd td  { background: #fff; }
 tr.even td { background: #dfe; }
 
+/* Odd or even, hovering will highlight the entire row */
+table tr:hover td { background: #ff0; }
+
 th { background: #eee; }
 
 /* The optional news banner (BILLTRACKER_INFO) and alert (BILLTRACKER_ALERT)


### PR DESCRIPTION
On wide browser windows, it's hard for my old eyes to match a checkbox (far right) against bill number or name. Add CSS to highlight entire rows on hover. (Sorry, no clue how to do that for mobile devices)

Signed-off-by: Eduardo Santiago <ed@edsantiago.com>